### PR TITLE
Fixed Encryption & Decryption Bug

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -18,7 +18,7 @@ for i in range(0, length):
         calculatedASCII = alphabetASCII - numberOfShifts
         if(calculatedASCII < lowerLimit):
             calculatedASCII = lowerLimit - calculatedASCII
-            calculatedASCII = upperLimit - calculatedASCII
+            calculatedASCII = (upperLimit + 1) - calculatedASCII
             decryptedString += chr(calculatedASCII)
         else:
             decryptedString += chr(calculatedASCII)
@@ -29,7 +29,10 @@ for i in range(0, length):
         calculatedASCII = alphabetASCII - numberOfShifts
         if(calculatedASCII < lowerLimit):
             calculatedASCII = lowerLimit - calculatedASCII
-            calculatedASCII = upperLimit - calculatedASCII
+
+            
+
+            calculatedASCII = (upperLimit + 1) - calculatedASCII
             decryptedString += chr(calculatedASCII)
         else:
             decryptedString += chr(calculatedASCII)

--- a/encrypt.py
+++ b/encrypt.py
@@ -18,7 +18,7 @@ for i in range(0, length):
         calculatedASCII = alphabetASCII + numberOfShifts
         if(calculatedASCII > upperLimit):
             calculatedASCII -=upperLimit
-            calculatedASCII += lowerLimit
+            calculatedASCII += lowerLimit - 1
             encryptedString += chr(calculatedASCII)
         else:
             encryptedString += chr(calculatedASCII)
@@ -29,7 +29,10 @@ for i in range(0, length):
         calculatedASCII = alphabetASCII + numberOfShifts
         if(calculatedASCII > upperLimit):
             calculatedASCII -=upperLimit
-            calculatedASCII += lowerLimit
+
+            # Minus one so that shift starts from 65 instead of 66
+
+            calculatedASCII += lowerLimit - 1
             encryptedString += chr(calculatedASCII)
         else:
             encryptedString += chr(calculatedASCII)


### PR DESCRIPTION
So When I encrypt the message which exceeds the upper limit i.e 122 it encrypts alphabet one value less than the respected alphabet. So Simply, Add One to the alphabet to get the correct alphabet.

Similarly with Decryption but here, instead of adding we'll have to subtract because as the value here could be less than the lower limit and after calculating ASCII value it decrypts the value by one greater than the desired alphabet.  